### PR TITLE
修复待审文章数大于4小于10时一直显示为9

### DIFF
--- a/coreframe/app/core/admin/template/listing.tpl.php
+++ b/coreframe/app/core/admin/template/listing.tpl.php
@@ -399,7 +399,7 @@
         } else if(count>100) {
             div_by = 50;
         }
-        var speed = Math.round(count / div_by),
+        var speed = Math.floor(count / div_by),
             $display = $('#'+id),
             run_count = 1,
             int_speed = 1;


### PR DESCRIPTION
402行的round函数应改为floor函数，详见[issue161](https://github.com/wuzhicms/wuzhicms/issues/161)